### PR TITLE
Five minute integration

### DIFF
--- a/catalyst/__main__.py
+++ b/catalyst/__main__.py
@@ -291,6 +291,13 @@ def catalyst_magic(line, cell=None):
     help='The data bundle to ingest.',
 )
 @click.option(
+    '-c',
+    '--compile-locally',
+    is_flag=True,
+    default=False,
+    help='Download dataset from source and compile bundle locally.',
+)
+@click.option(
     '--assets-version',
     type=int,
     multiple=True,
@@ -301,7 +308,7 @@ def catalyst_magic(line, cell=None):
     default=True,
     help='Print progress information to the terminal.'
 )
-def ingest(bundle, assets_version, show_progress):
+def ingest(bundle, compile_locally, assets_version, show_progress):
     """Ingest the data for the given bundle.
     """
     bundles_module.ingest(
@@ -310,6 +317,7 @@ def ingest(bundle, assets_version, show_progress):
         pd.Timestamp.utcnow(),
         assets_version,
         show_progress,
+        compile_locally,
     )
 
 

--- a/catalyst/algorithm.py
+++ b/catalyst/algorithm.py
@@ -431,6 +431,7 @@ class TradingAlgorithm(object):
 
         If get_loader is None, constructs an ExplodingPipelineEngine
         """
+        print 'using all_dates for {}'.format(data_frequency)
         if get_loader is not None:
             if data_frequency == 'daily':
                 all_dates = self.trading_calendar.all_sessions

--- a/catalyst/algorithm.py
+++ b/catalyst/algorithm.py
@@ -1712,12 +1712,12 @@ class TradingAlgorithm(object):
         return dt
 
     @api_method
-    def set_slippage(self, us_equities=None, us_futures=None):
+    def set_slippage(self, equities=None, us_futures=None):
         """Set the slippage models for the simulation.
 
         Parameters
         ----------
-        us_equities : EquitySlippageModel
+        equities : EquitySlippageModel
             The slippage model to use for trading US equities.
         us_futures : FutureSlippageModel
             The slippage model to use for trading US futures.
@@ -1729,14 +1729,14 @@ class TradingAlgorithm(object):
         if self.initialized:
             raise SetSlippagePostInit()
 
-        if us_equities is not None:
-            if Equity not in us_equities.allowed_asset_types:
+        if equities is not None:
+            if Equity not in equities.allowed_asset_types:
                 raise IncompatibleSlippageModel(
                     asset_type='equities',
-                    given_model=us_equities,
-                    supported_asset_types=us_equities.allowed_asset_types,
+                    given_model=equities,
+                    supported_asset_types=equities.allowed_asset_types,
                 )
-            self.blotter.slippage_models[Equity] = us_equities
+            self.blotter.slippage_models[Equity] = equities
 
         if us_futures is not None:
             if Future not in us_futures.allowed_asset_types:
@@ -1748,12 +1748,12 @@ class TradingAlgorithm(object):
             self.blotter.slippage_models[Future] = us_futures
 
     @api_method
-    def set_commission(self, us_equities=None, us_futures=None):
+    def set_commission(self, equities=None, us_futures=None):
         """Sets the commission models for the simulation.
 
         Parameters
         ----------
-        us_equities : EquityCommissionModel
+        equities : EquityCommissionModel
             The commission model to use for trading US equities.
         us_futures : FutureCommissionModel
             The commission model to use for trading US futures.
@@ -1767,14 +1767,14 @@ class TradingAlgorithm(object):
         if self.initialized:
             raise SetCommissionPostInit()
 
-        if us_equities is not None:
-            if Equity not in us_equities.allowed_asset_types:
+        if equities is not None:
+            if Equity not in equities.allowed_asset_types:
                 raise IncompatibleCommissionModel(
                     asset_type='equities',
-                    given_model=us_equities,
-                    supported_asset_types=us_equities.allowed_asset_types,
+                    given_model=equities,
+                    supported_asset_types=equities.allowed_asset_types,
                 )
-            self.blotter.commission_models[Equity] = us_equities
+            self.blotter.commission_models[Equity] = equities
 
         if us_futures is not None:
             if Future not in us_futures.allowed_asset_types:

--- a/catalyst/algorithm.py
+++ b/catalyst/algorithm.py
@@ -308,7 +308,10 @@ class TradingAlgorithm(object):
         self.asset_finder = self.trading_environment.asset_finder
 
         # Initialize Pipeline API data.
-        self.init_engine(kwargs.pop('get_pipeline_loader', None))
+        self.init_engine(
+            kwargs.pop('get_pipeline_loader', None),
+            self.sim_params.data_frequency,
+        )
         self._pipelines = {}
         # Create an always-expired cache so that we compute the first time data
         # is requested.
@@ -422,16 +425,31 @@ class TradingAlgorithm(object):
 
         self.restrictions = NoRestrictions()
 
-    def init_engine(self, get_loader):
+    def init_engine(self, get_loader, data_frequency):
         """
         Construct and store a PipelineEngine from loader.
 
         If get_loader is None, constructs an ExplodingPipelineEngine
         """
         if get_loader is not None:
+            if data_frequency == 'daily':
+                all_dates = self.trading_calendar.all_sessions
+            elif data_frequency == '5-minute':
+                all_dates = self.trading_calendar.all_five_minutes
+            elif data_frequency == 'minute':
+                all_dates = self.trading_calendar.all_minutes
+            else:
+                raise ValueError(
+                    'Cannot initialize engine with '
+                    'data frequency: {}'.format(data_frequency)
+                )
+
+            print 'first_dates:', all_dates[:10]
+            print 'last_dates:', all_dates[:-10]
+
             self.engine = SimplePipelineEngine(
                 get_loader,
-                self.trading_calendar.all_sessions,
+                all_dates,
                 self.asset_finder,
             )
         else:

--- a/catalyst/data/_minute_bar_internal.pyx
+++ b/catalyst/data/_minute_bar_internal.pyx
@@ -35,6 +35,17 @@ def minute_value(ndarray[long_t, ndim=1] market_opens,
 
     return market_opens[q] + r
 
+@cython.cdivision(True)
+def five_minute_value(ndarray[long_t, ndim=1] market_opens,
+                      Py_ssize_t pos,
+                      short five_minutes_per_day):
+
+    cdef short q, r
+    q = cython.cdiv(pos, five_minutes_per_day)
+    r = cython.cmod(pos, five_minutes_per_day)
+
+    return market_opens[q] + r
+
 def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
                             ndarray[long_t, ndim=1] market_closes,
                             long_t minute_val,
@@ -87,6 +98,26 @@ def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
     delta = int_min(minute_val - market_open, market_close - market_open)
 
     return (market_open_loc * minutes_per_day) + delta
+
+def find_position_of_five_minute(ndarray[long_t, ndim=1] market_opens,
+                                 ndarray[long_t, ndim=1] market_closes,
+                                 long_t five_minute_val,
+                                 short five_minutes_per_day,
+                                 bool forward_fill):
+
+    cdef Py_ssize_t market_open_loc, market_open, delta
+
+    market_open_loc = \
+        searchsorted(market_opens, five_minute_val, side='right') - 1
+    market_open = market_opens[market_open_loc]
+    market_close = market_closes[market_open_loc]
+
+    if not forward_fill and ((five_minute_val - market_open) >= five_minutes_per_day):
+        raise ValueError("Given five minutes is not between an open and a close")
+
+    delta = int_min(five_minute_val - market_open, market_close - market_open)
+
+    return (market_open_loc * five_minutes_per_day) + delta
 
 def find_last_traded_position_internal(
         ndarray[long_t, ndim=1] market_opens,
@@ -153,6 +184,54 @@ def find_last_traded_position_internal(
             return minute_pos
 
         minute_pos -= 1
+
+    # we've gone to the beginning of this asset's range, and still haven't
+    # found a trade event
+    return -1
+
+def find_last_traded_five_minute_position_internal(
+        ndarray[long_t, ndim=1] market_opens,
+        ndarray[long_t, ndim=1] market_closes,
+        long_t end_five_minute,
+        long_t start_five_minute,
+        volumes,
+        short five_minutes_per_day):
+    cdef Py_ssize_t minute_pos, current_minute, q
+
+    five_minute_pos = int_min(
+        find_position_of_five_minute(
+            market_opens,
+            market_closes,
+            end_five_minute,
+            five_minutes_per_day,
+            True,
+        ),
+        len(volumes) - 1,
+    )
+
+    while five_minute_pos >= 0:
+        current_five_minute = five_minute_value(
+            market_opens, five_minute_pos, five_minutes_per_day
+        )
+
+        q = cython.cdiv(five_minute_pos, five_minutes_per_day)
+        if current_five_minute > market_closes[q]:
+            five_minute_pos = find_position_of_five_minute(
+                market_opens,
+                market_closes,
+                market_closes[q],
+                five_minutes_per_day,
+                False,
+            )
+            continue
+
+        if current_five_minute < start_five_minute:
+            return -1
+
+        if volumes[five_minute_pos] != 0:
+            return five_minute_pos
+
+        five_minute_pos -= 1
 
     # we've gone to the beginning of this asset's range, and still haven't
     # found a trade event

--- a/catalyst/data/_minute_bar_internal.pyx
+++ b/catalyst/data/_minute_bar_internal.pyx
@@ -44,7 +44,7 @@ def five_minute_value(ndarray[long_t, ndim=1] market_opens,
     q = cython.cdiv(pos, five_minutes_per_day)
     r = cython.cmod(pos, five_minutes_per_day)
 
-    return market_opens[q] + r
+    return market_opens[q] + 5 * r
 
 def find_position_of_minute(ndarray[long_t, ndim=1] market_opens,
                             ndarray[long_t, ndim=1] market_closes,
@@ -112,10 +112,14 @@ def find_position_of_five_minute(ndarray[long_t, ndim=1] market_opens,
     market_open = market_opens[market_open_loc]
     market_close = market_closes[market_open_loc]
 
-    if not forward_fill and ((five_minute_val - market_open) >= five_minutes_per_day):
+    val_open_offset = (five_minute_val - market_open)/5
+    close_open_offset = (market_close - market_open)/5
+
+    if not forward_fill and val_open_offset >= five_minutes_per_day:
         raise ValueError("Given five minutes is not between an open and a close")
 
-    delta = int_min(five_minute_val - market_open, market_close - market_open)
+    # clamp offset to close index
+    delta = int_min(val_open_offset, close_open_offset)
 
     return (market_open_loc * five_minutes_per_day) + delta
 

--- a/catalyst/data/bundles/base_pricing.py
+++ b/catalyst/data/bundles/base_pricing.py
@@ -38,9 +38,6 @@ class BasePricingBundle(BaseBundle):
         ]
 
 class BaseCryptoPricingBundle(BasePricingBundle):
-    def __init__(self):
-        super(BasePricingBundle, self).__init__()
-
     @lazyval
     def calendar_name(self):
         return 'OPEN'
@@ -48,6 +45,10 @@ class BaseCryptoPricingBundle(BasePricingBundle):
     @lazyval
     def minutes_per_day(self):
         return 1440
+
+    @lazyval
+    def five_minutes_per_day(self):
+        return 288
 
     @property
     def splits(self):
@@ -58,11 +59,6 @@ class BaseCryptoPricingBundle(BasePricingBundle):
         return []
 
 class BaseEquityPricingBundle(BasePricingBundle):
-    def __init__(self):
-        super(BasePricingBundle, self).__init__()
-        self._splits = []
-        self._dividends = []
-
     @lazyval
     def calendar_name(self):
         return 'NYSE'
@@ -71,6 +67,9 @@ class BaseEquityPricingBundle(BasePricingBundle):
     def minutes_per_day(self):
         return 390
 
+    @lazyval
+    def five_minutes_per_day(self):
+        return 78
 
     @property
     def splits(self):

--- a/catalyst/data/bundles/base_pricing.py
+++ b/catalyst/data/bundles/base_pricing.py
@@ -38,6 +38,9 @@ class BasePricingBundle(BaseBundle):
         ]
 
 class BaseCryptoPricingBundle(BasePricingBundle):
+    def __init__(self):
+        super(BasePricingBundle, self).__init__()
+
     @lazyval
     def calendar_name(self):
         return 'OPEN'
@@ -46,7 +49,20 @@ class BaseCryptoPricingBundle(BasePricingBundle):
     def minutes_per_day(self):
         return 1440
 
+    @property
+    def splits(self):
+        return []
+
+    @property
+    def dividends(self):
+        return []
+
 class BaseEquityPricingBundle(BasePricingBundle):
+    def __init__(self):
+        super(BasePricingBundle, self).__init__()
+        self._splits = []
+        self._dividends = []
+
     @lazyval
     def calendar_name(self):
         return 'NYSE'
@@ -54,3 +70,12 @@ class BaseEquityPricingBundle(BasePricingBundle):
     @lazyval
     def minutes_per_day(self):
         return 390
+
+
+    @property
+    def splits(self):
+        return self._splits
+
+    @property
+    def dividends(self):
+        return self._dividends

--- a/catalyst/data/bundles/core.py
+++ b/catalyst/data/bundles/core.py
@@ -17,6 +17,10 @@ from ..us_equity_pricing import (
     SQLiteAdjustmentReader,
     SQLiteAdjustmentWriter,
 )
+from ..five_minute_bars import (
+    BcolzFiveMinuteBarReader,
+    BcolzFiveMinuteBarWriter,
+)
 from ..minute_bars import (
     BcolzMinuteBarReader,
     BcolzMinuteBarWriter,
@@ -44,16 +48,21 @@ def asset_db_path(bundle_name, timestr, environ=None, db_version=None):
     )
 
 
-def minute_equity_path(bundle_name, timestr, environ=None):
+def minute_path(bundle_name, timestr, environ=None):
     return pth.data_path(
-        minute_equity_relative(bundle_name, timestr, environ),
+        minute_relative(bundle_name, timestr, environ),
         environ=environ,
     )
 
-
-def daily_equity_path(bundle_name, timestr, environ=None):
+def five_minute_path(bundle_name, timestr, environ=None):
     return pth.data_path(
-        daily_equity_relative(bundle_name, timestr, environ),
+        five_minute_relative(bundle_name, timestr, environ),
+        environ=environ,
+    )
+
+def daily_path(bundle_name, timestr, environ=None):
+    return pth.data_path(
+        daily_relative(bundle_name, timestr, environ),
         environ=environ,
     )
 
@@ -80,12 +89,14 @@ def cache_relative(bundle_name, timestr, environ=None):
     return bundle_name, '.cache'
 
 
-def daily_equity_relative(bundle_name, timestr, environ=None):
-    return bundle_name, timestr, 'daily_equities.bcolz'
+def daily_relative(bundle_name, timestr, environ=None):
+    return bundle_name, timestr, 'daily.bcolz'
 
+def five_minute_relative(bundle_name, timestr, environ=None):
+    return bundle_name, timestr, 'five_minute.bcolz'
 
-def minute_equity_relative(bundle_name, timestr, environ=None):
-    return bundle_name, timestr, 'minute_equities.bcolz'
+def minute_relative(bundle_name, timestr, environ=None):
+    return bundle_name, timestr, 'minute.bcolz'
 
 
 def asset_db_relative(bundle_name, timestr, environ=None, db_version=None):
@@ -195,13 +206,14 @@ RegisteredBundle = namedtuple(
      'start_session',
      'end_session',
      'minutes_per_day',
+     'five_minutes_per_day',
      'ingest',
      'create_writers']
 )
 
 BundleData = namedtuple(
     'BundleData',
-    'asset_finder equity_minute_bar_reader equity_daily_bar_reader '
+    'asset_finder minute_bar_reader five_minute_bar_reader daily_bar_reader '
     'adjustment_reader',
 )
 
@@ -281,15 +293,17 @@ def _make_bundle_core():
     bundles = mappingproxy(_bundles)
 
     def register_bundle(bundle_cls,
+                        asset_filter=None,
                         start_session=None,
                         end_session=None,
                         create_writers=True):
-        bundle = bundle_cls()
+        bundle = bundle_cls(asset_filter=asset_filter)
         return register(
             bundle.name,
             bundle.ingest,
             calendar_name=bundle.calendar_name,
             minutes_per_day=bundle.minutes_per_day,
+            five_minutes_per_day=bundle.five_minutes_per_day,
             start_session=start_session,
             end_session=end_session,
             create_writers=create_writers,
@@ -298,10 +312,11 @@ def _make_bundle_core():
     @curry
     def register(name,
                  f,
-                 calendar_name='NYSE',
+                 calendar_name='OPEN',
                  start_session=None,
                  end_session=None,
-                 minutes_per_day=390,
+                 minutes_per_day=1440,
+                 five_minutes_per_day=288,
                  create_writers=True):
         """Register a data bundle ingest function.
 
@@ -382,6 +397,7 @@ def _make_bundle_core():
             start_session=start_session,
             end_session=end_session,
             minutes_per_day=minutes_per_day,
+            five_minutes_per_day=five_minutes_per_day,
             ingest=f,
             create_writers=create_writers,
         )
@@ -413,7 +429,8 @@ def _make_bundle_core():
                environ=os.environ,
                timestamp=None,
                assets_versions=(),
-               show_progress=False):
+               show_progress=False,
+               is_compile=False):
         """Ingest data for a given bundle.
 
         Parameters
@@ -463,7 +480,7 @@ def _make_bundle_core():
                     pth.data_path([], environ=environ))
                 )
                 daily_bars_path = wd.ensure_dir(
-                    *daily_equity_relative(
+                    *daily_relative(
                         name, timestr, environ=environ,
                     )
                 )
@@ -477,10 +494,20 @@ def _make_bundle_core():
                 # when we create the SQLiteAdjustmentWriter below. The
                 # SQLiteAdjustmentWriter needs to open the daily ctables so
                 # that it can compute the adjustment ratios for the dividends.
-
                 daily_bar_writer.write(())
+
+                five_minute_bar_writer = BcolzFiveMinuteBarWriter(
+                    wd.ensure_dir(*five_minute_relative(
+                        name, timestr, environ=environ)
+                    ),
+                    calendar,
+                    start_session,
+                    end_session,
+                    five_minutes_per_day=bundle.five_minutes_per_day,
+                )
+
                 minute_bar_writer = BcolzMinuteBarWriter(
-                    wd.ensure_dir(*minute_equity_relative(
+                    wd.ensure_dir(*minute_relative(
                         name, timestr, environ=environ)
                     ),
                     calendar,
@@ -488,6 +515,7 @@ def _make_bundle_core():
                     end_session,
                     minutes_per_day=bundle.minutes_per_day,
                 )
+
                 assets_db_path = wd.getpath(*asset_db_relative(
                     name, timestr, environ=environ,
                 ))
@@ -504,6 +532,7 @@ def _make_bundle_core():
                 )
             else:
                 daily_bar_writer = None
+                five_minute_bar_writer = None
                 minute_bar_writer = None
                 asset_db_writer = None
                 adjustment_db_writer = None
@@ -515,6 +544,7 @@ def _make_bundle_core():
                 environ,
                 asset_db_writer,
                 minute_bar_writer,
+                five_minute_bar_writer,
                 daily_bar_writer,
                 adjustment_db_writer,
                 calendar,
@@ -522,6 +552,7 @@ def _make_bundle_core():
                 end_session,
                 cache,
                 show_progress,
+                is_compile,
                 pth.data_path([name, timestr], environ=environ),
             )
 
@@ -597,11 +628,14 @@ def _make_bundle_core():
             asset_finder=AssetFinder(
                 asset_db_path(name, timestr, environ=environ),
             ),
-            equity_minute_bar_reader=BcolzMinuteBarReader(
-                minute_equity_path(name, timestr, environ=environ),
+            minute_bar_reader=BcolzMinuteBarReader(
+                minute_path(name, timestr, environ=environ),
             ),
-            equity_daily_bar_reader=BcolzDailyBarReader(
-                daily_equity_path(name, timestr, environ=environ),
+            five_minute_bar_reader=BcolzFiveMinuteBarReader(
+                five_minute_path(name, timestr, environ=environ),
+            ),
+            daily_bar_reader=BcolzDailyBarReader(
+                daily_path(name, timestr, environ=environ),
             ),
             adjustment_reader=SQLiteAdjustmentReader(
                 adjustment_db_path(name, timestr, environ=environ),

--- a/catalyst/data/bundles/poloniex.py
+++ b/catalyst/data/bundles/poloniex.py
@@ -67,15 +67,17 @@ class PoloniexBundle(BaseCryptoPricingBundle):
             inplace=True,
         )
 
+        raw = raw[raw['isFrozen'] == 0]
+
         return raw
 
-    def post_process_symbol_metadata(self, metadata, data):
-        start_date = data.index[0].tz_localize(None)
-        end_date = data.index[-1].tz_localize(None)
+    def post_process_symbol_metadata(self, asset_id, sym_md, sym_data):
+        start_date = sym_data.index[0].tz_localize(None)
+        end_date = sym_data.index[-1].tz_localize(None)
         ac_date = end_date + pd.Timedelta(days=1)
 
         return (
-            metadata.symbol,
+            sym_md.symbol,
             start_date,
             end_date,
             ac_date,
@@ -84,6 +86,7 @@ class PoloniexBundle(BaseCryptoPricingBundle):
     def fetch_raw_symbol_frame(self,
                                api_key,
                                symbol,
+                               calendar,
                                start_date,
                                end_date,
                                frequency):
@@ -130,7 +133,6 @@ class PoloniexBundle(BaseCryptoPricingBundle):
         period_map = {
             'daily': 86400,
             '5-minute': 300,
-            'minute': 60,
         }
 
         try:

--- a/catalyst/data/bundles/poloniex.py
+++ b/catalyst/data/bundles/poloniex.py
@@ -36,6 +36,7 @@ class PoloniexBundle(BaseCryptoPricingBundle):
     def frequencies(self):
         return set((
             'daily',
+            '5-minute',
         ))
 
     @lazyval
@@ -72,8 +73,8 @@ class PoloniexBundle(BaseCryptoPricingBundle):
         return raw
 
     def post_process_symbol_metadata(self, asset_id, sym_md, sym_data):
-        start_date = sym_data.index[0].tz_localize(None)
-        end_date = sym_data.index[-1].tz_localize(None)
+        start_date = sym_data.index[0]
+        end_date = sym_data.index[-1]
         ac_date = end_date + pd.Timedelta(days=1)
 
         return (
@@ -100,7 +101,6 @@ class PoloniexBundle(BaseCryptoPricingBundle):
             ),
             orient='records',
         )
-
         raw.set_index('date', inplace=True)
 
         scale = 1000.0
@@ -155,4 +155,4 @@ class PoloniexBundle(BaseCryptoPricingBundle):
             query=urlencode(query_params),
         )
 
-register_bundle(PoloniexBundle)
+register_bundle(PoloniexBundle, ['USDT_BTC'])

--- a/catalyst/data/bundles/quandl.py
+++ b/catalyst/data/bundles/quandl.py
@@ -1,3 +1,28 @@
+#
+# Copyright 2017 Enigma MPC, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+
+import pandas as pd
+
+from six.moves.urllib.parse import urlencode
+
+from catalyst.data.bundles.core import register_bundle
+from catalyst.data.bundles.base_pricing import BaseEquityPricingBundle
+from catalyst.utils.memoize import lazyval
+
 """
 Module for building a complete daily dataset from Quandl's WIKI dataset.
 """
@@ -17,350 +42,190 @@ from . import core as bundles
 
 log = Logger(__name__)
 seconds_per_call = (pd.Timedelta('10 minutes') / 2000).total_seconds()
-# Invalid symbols that quandl has had in its metadata:
-excluded_symbols = frozenset({'TEST123456789'})
 
+class QuandlBundle(BaseEquityPricingBundle):
+    @lazyval
+    def name(self):
+        return 'quandl'
 
-def _fetch_raw_metadata(api_key, cache, retries, environ):
-    """Generator that yields each page of data from the metadata endpoint
-    as a dataframe.
-    """
-    for page_number in count(1):
-        key = 'metadata-page-%d' % page_number
-        try:
-            raw = cache[key]
-        except KeyError:
-            for _ in range(retries):
-                try:
-                    raw = pd.read_csv(
-                        format_metadata_url(api_key, page_number),
-                        date_parser=pd.tseries.tools.to_datetime,
-                        parse_dates=[
-                            'oldest_available_date',
-                            'newest_available_date',
-                        ],
-                        dtypes={
-                            'dataset_code': 'int',
-                            'name': 'str',
-                            'oldest_available_date': 'str',
-                            'newest_available_date': 'str',
-                        },
-                        usecols=[
-                            'dataset_code',
-                            'name',
-                            'oldest_available_date',
-                            'newest_available_date',
-                        ],
-                    )
-                    break
-                except ValueError:
-                    # when we are past the last page we will get a value
-                    # error because there will be no columns
-                    raw = pd.DataFrame([])
-                    break
-                except Exception:
-                    pass
-            else:
-                raise ValueError(
-                    'Failed to download metadata page %d after %d'
-                    ' attempts.' % (page_number, retries),
-                )
+    @lazyval
+    def exchange(self):
+        return 'QUANDL'
 
-            cache[key] = raw
+    @lazyval
+    def frequencies(self):
+        return set(('daily',))
 
-        if raw.empty:
-            # use the empty dataframe to signal completion
-            break
-        yield raw
+    @lazyval
+    def tar_url(self):
+        return 'https://s3.amazonaws.com/quantopian-public-zipline-data/quandl'
 
+    @lazyval
+    def wait_time(self):
+        return pd.Timedelta(milliseconds=300)
 
-def fetch_symbol_metadata_frame(api_key,
-                                cache,
-                                retries=5,
-                                environ=None,
-                                show_progress=False):
-    """
-    Download Quandl symbol metadata.
+    @lazyval
+    def _excluded_symbols(self):
+        """
+        Invalid symbols that quandl has had in its metadata:
+        """
+        return frozenset({'TEST123456789'})
 
-    Parameters
-    ----------
-    api_key : str
-        The quandl api key to use. If this is None then no api key will be
-        sent.
-    cache : DataFrameCache
-        The cache to use for persisting the intermediate data.
-    retries : int, optional
-        The number of times to retry each request before failing.
-    environ : mapping[str -> str], optional
-        The environment to use to find the catalyst home. By default this
-        is ``os.environ``.
-    show_progress : bool, optional
-        Show a progress bar for the download of this data.
-
-    Returns
-    -------
-    metadata_frame : pd.DataFrame
-        A dataframe with the following columns:
-          symbol: the asset's symbol
-          name: the full name of the asset
-          start_date: the first date of data for this asset
-          end_date: the last date of data for this asset
-          auto_close_date: end_date + one day
-          exchange: the exchange for the asset; this is always 'quandl'
-        The index of the dataframe will be used for symbol->sid mappings but
-        otherwise does not have specific meaning.
-    """
-    raw_iter = _fetch_raw_metadata(api_key, cache, retries, environ)
-
-    def item_show_func(_, _it=iter(count())):
-        'Downloading page: %d' % next(_it)
-
-    with maybe_show_progress(raw_iter,
-                             show_progress,
-                             item_show_func=item_show_func,
-                             label='Downloading WIKI metadata: ') as blocks:
-        data = pd.concat(blocks, ignore_index=True).rename(columns={
-            'dataset_code': 'symbol',
-            'name': 'asset_name',
-            'oldest_available_date': 'start_date',
-            'newest_available_date': 'end_date',
-        }).sort_values('symbol')
-
-    data = data[~data.symbol.isin(excluded_symbols)]
-    # cut out all the other stuff in the name column
-    # we need to escape the paren because it is actually splitting on a regex
-    data.asset_name = data.asset_name.str.split(r' \(', 1).str.get(0)
-    data['exchange'] = 'QUANDL'
-
-    data['start_date'] = data['start_date'].astype(datetime)
-    data['end_date'] = data['end_date'].astype(datetime)
-
-    data['auto_close_date'] = data['end_date'] + pd.Timedelta(days=1)
-    return data
-
-
-def format_metadata_url(api_key, page_number):
-    """Build the query RL for the quandl WIKI metadata.
-    """
-    query_params = [
-        ('per_page', '100'),
-        ('sort_by', 'id'),
-        ('page', str(page_number)),
-        ('database_code', 'WIKI'),
-    ]
-    if api_key is not None:
-        query_params = [('api_key', api_key)] + query_params
-    return (
-        'https://www.quandl.com/api/v3/datasets.csv?' + urlencode(query_params)
-    )
-
-
-def format_wiki_url(api_key, symbol, start_date, end_date):
-    """
-    Build a query URL for a quandl WIKI dataset.
-    """
-    query_params = [
-        ('start_date', start_date.strftime('%Y-%m-%d')),
-        ('end_date', end_date.strftime('%Y-%m-%d')),
-        ('order', 'asc'),
-    ]
-    if api_key is not None:
-        query_params = [('api_key', api_key)] + query_params
-
-    return (
-        "https://www.quandl.com/api/v3/datasets/WIKI/"
-        "{symbol}.csv?{query}".format(
-            symbol=symbol,
-            query=urlencode(query_params),
-        )
-    )
-
-
-def fetch_single_equity(api_key,
-                        symbol,
-                        start_date,
-                        end_date,
-                        retries=5):
-    """
-    Download data for a single equity.
-    """
-    for _ in range(retries):
-        try:
-            return pd.read_csv(
-                format_wiki_url(api_key, symbol, start_date, end_date),
-                parse_dates=['Date'],
-                index_col='Date',
-                usecols=[
-                    'Open',
-                    'High',
-                    'Low',
-                    'Close',
-                    'Volume',
-                    'Date',
-                    'Ex-Dividend',
-                    'Split Ratio',
-                ],
-                na_values=['NA'],
-            ).rename(columns={
-                'Open': 'open',
-                'High': 'high',
-                'Low': 'low',
-                'Close': 'close',
-                'Volume': 'volume',
-                'Date': 'date',
-                'Ex-Dividend': 'ex_dividend',
-                'Split Ratio': 'split_ratio',
-            })
-        except Exception:
-            log.exception("Exception raised reading Quandl data. Retrying.")
-    else:
-        raise ValueError(
-            "Failed to download data for %r after %d attempts." % (
-                symbol, retries
-            )
+    def fetch_raw_metadata_frame(self, api_key, page_number):
+        raw = pd.read_csv(
+            self._format_metadata_url(api_key, page_number),
+            date_parser=pd.tseries.tools.to_datetime,
+            parse_dates=[
+                'oldest_available_date',
+                'newest_available_date',
+            ],
+            dtype={
+                'dataset_code': 'str',
+                'name': 'str',
+                'oldest_available_date': 'str',
+                'newest_available_date': 'str',
+            },
+            usecols=[
+                'dataset_code',
+                'name',
+                'oldest_available_date',
+                'newest_available_date',
+            ],
+        ).rename(
+            columns={
+                'dataset_code': 'symbol',
+                'name': 'asset_name',
+                'oldest_available_date': 'start_date',
+                'newest_available_date': 'end_date',
+            },
         )
 
+        raw['start_date'] = raw['start_date'].astype(datetime)
+        raw['end_date'] = raw['end_date'].astype(datetime)
+        raw['ac_date'] = raw['end_date'] + pd.Timedelta(days=1)
 
-def _update_splits(splits, asset_id, raw_data):
-    split_ratios = raw_data.split_ratio
-    df = pd.DataFrame({'ratio': 1 / split_ratios[split_ratios != 1]})
-    df.index.name = 'effective_date'
-    df.reset_index(inplace=True)
-    df['sid'] = asset_id
-    splits.append(df)
+        # Filter out invalid symbols
+        raw = raw[~raw.symbol.isin(self._excluded_symbols)]
 
+        # cut out all the other stuff in the name column
+        # we need to escape the paren because it is actually splitting on a regex
+        raw.asset_name = raw.asset_name.str.split(r' \(', 1).str.get(0)
 
-def _update_dividends(dividends, asset_id, raw_data):
-    divs = raw_data.ex_dividend
-    df = pd.DataFrame({'amount': divs[divs != 0]})
-    df.index.name = 'ex_date'
-    df.reset_index(inplace=True)
-    df['sid'] = asset_id
-    # we do not have this data in the WIKI dataset
-    df['record_date'] = df['declared_date'] = df['pay_date'] = pd.NaT
-    dividends.append(df)
+        return raw
 
-
-def gen_symbol_data(api_key,
-                    cache,
-                    symbol_map,
-                    calendar,
-                    start_session,
-                    end_session,
-                    splits,
-                    dividends,
-                    retries):
-    for asset_id, symbol in symbol_map.iteritems():
-        start_time = time()
-        try:
-            # see if we have this data cached.
-            raw_data = cache[symbol]
-            should_sleep = False
-        except KeyError:
-            # we need to fetch the data and then write it to our cache
-            raw_data = cache[symbol] = fetch_single_equity(
+    def fetch_raw_symbol_frame(self,
+                               api_key,
+                               symbol,
+                               calendar,
+                               start_session,
+                               end_session,
+                               data_frequency):
+        raw_data = pd.read_csv(
+            self._format_wiki_url(
                 api_key,
                 symbol,
-                start_date=start_session,
-                end_date=end_session,
-            )
-            should_sleep = True
-
-        _update_splits(splits, asset_id, raw_data)
-        _update_dividends(dividends, asset_id, raw_data)
+                start_session,
+                end_session,
+                data_frequency,
+            ),
+            parse_dates=['Date'],
+            index_col='Date',
+            usecols=[
+                'Open',
+                'High',
+                'Low',
+                'Close',
+                'Volume',
+                'Date',
+                'Ex-Dividend',
+                'Split Ratio',
+            ],
+            na_values=['NA'],
+        ).rename(columns={
+            'Open': 'open',
+            'High': 'high',
+            'Low': 'low',
+            'Close': 'close',
+            'Volume': 'volume',
+            'Date': 'date',
+            'Ex-Dividend': 'ex_dividend',
+            'Split Ratio': 'split_ratio',
+        })
 
         sessions = calendar.sessions_in_range(start_session, end_session)
 
-        raw_data = raw_data.reindex(
+        return raw_data.reindex(
             sessions.tz_localize(None),
             copy=False,
         ).fillna(0.0)
-        yield asset_id, raw_data
 
-        if should_sleep:
-            remaining = seconds_per_call - time() - start_time
-            if remaining > 0:
-                sleep(remaining)
+    def post_process_symbol_metadata(self, asset_id, sym_md, sym_data):
+        self._update_splits(asset_id, sym_data)
+        self._update_dividends(asset_id, sym_data)
 
+        return sym_md
 
-@bundles.register('quandl')
-def quandl_bundle(environ,
-                  asset_db_writer,
-                  minute_bar_writer,
-                  daily_bar_writer,
-                  adjustment_writer,
-                  calendar,
-                  start_session,
-                  end_session,
-                  cache,
-                  show_progress,
-                  output_dir):
-    """Build a catalyst data bundle from the Quandl WIKI dataset.
-    """
-    api_key = environ.get('QUANDL_API_KEY')
-    metadata = fetch_symbol_metadata_frame(
-        api_key,
-        cache=cache,
-        show_progress=show_progress,
-    )
-    symbol_map = metadata.symbol
-
-    # data we will collect in `gen_symbol_data`
-    splits = []
-    dividends = []
-
-    asset_db_writer.write(metadata)
-    daily_bar_writer.write(
-        gen_symbol_data(
-            api_key,
-            cache,
-            symbol_map,
-            calendar,
-            start_session,
-            end_session,
-            splits,
-            dividends,
-            environ.get('QUANDL_DOWNLOAD_ATTEMPTS', 5),
-        ),
-        assets=metadata.index,
-        show_progress=show_progress,
-    )
-    adjustment_writer.write(
-        splits=pd.concat(splits, ignore_index=True),
-        dividends=pd.concat(dividends, ignore_index=True),
-    )
+    def _update_splits(self, asset_id, raw_data):
+        split_ratios = raw_data.split_ratio
+        df = pd.DataFrame({'ratio': 1 / split_ratios[split_ratios != 1]})
+        df.index.name = 'effective_date'
+        df.reset_index(inplace=True)
+        df['sid'] = asset_id
+        self.splits.append(df)
 
 
-QUANTOPIAN_QUANDL_URL = (
-    'https://s3.amazonaws.com/quantopian-public-zipline-data/quandl'
-)
+    def _update_dividends(self, asset_id, raw_data):
+        divs = raw_data.ex_dividend
+        df = pd.DataFrame({'amount': divs[divs != 0]})
+        df.index.name = 'ex_date'
+        df.reset_index(inplace=True)
+        df['sid'] = asset_id
+        # we do not have this data in the WIKI dataset
+        df['record_date'] = df['declared_date'] = df['pay_date'] = pd.NaT
+        self.dividends.append(df)
 
 
-@bundles.register('quantopian-quandl', create_writers=False)
-def quantopian_quandl_bundle(environ,
-                             asset_db_writer,
-                             minute_bar_writer,
-                             daily_bar_writer,
-                             adjustment_writer,
-                             calendar,
-                             start_session,
-                             end_session,
-                             cache,
-                             show_progress,
-                             output_dir):
-    if show_progress:
-        data = bundles.download_with_progress(
-            QUANTOPIAN_QUANDL_URL,
-            chunk_size=bundles.ONE_MEGABYTE,
-            label="Downloading Bundle: quantopian-quandl",
+    def _format_metadata_url(self, api_key, page_number):
+        """Build the query RL for the quandl WIKI metadata.
+        """
+        query_params = [
+            ('per_page', '100'),
+            ('sort_by', 'id'),
+            ('page', str(page_number)),
+            ('database_code', 'WIKI'),
+        ]
+        if api_key is not None:
+            query_params = [('api_key', api_key)] + query_params
+
+        return (
+            'https://www.quandl.com/api/v3/datasets.csv?' + urlencode(query_params)
         )
-    else:
-        data = bundles.download_without_progress(QUANTOPIAN_QUANDL_URL)
-
-    with tarfile.open('r', fileobj=data) as tar:
-        if show_progress:
-            print("Writing data to %s." % output_dir)
-        tar.extractall(output_dir)
 
 
-register_calendar_alias("QUANDL", "NYSE")
+    def _format_wiki_url(self,
+                         api_key,
+                         symbol,
+                         start_date,
+                         end_date,
+                         data_frequency):
+        """
+        Build a query URL for a quandl WIKI dataset.
+        """
+        query_params = [
+            ('start_date', start_date.strftime('%Y-%m-%d')),
+            ('end_date', end_date.strftime('%Y-%m-%d')),
+            ('order', 'asc'),
+        ]
+        if api_key is not None:
+            query_params = [('api_key', api_key)] + query_params
+
+        return (
+            "https://www.quandl.com/api/v3/datasets/WIKI/"
+            "{symbol}.csv?{query}".format(
+                symbol=symbol,
+                query=urlencode(query_params),
+            )
+        )
+
+register_calendar_alias('QUANDL', 'NYSE')
+register_bundle(QuandlBundle)

--- a/catalyst/data/data_portal.py
+++ b/catalyst/data/data_portal.py
@@ -689,9 +689,11 @@ class DataPortal(object):
 
             if pd.isnull(query_dt):
                 # no last traded dt, bail
+                print 'ffill, no dt {} for, {}'.format(query_dt, column)
                 if column == 'volume':
                     return 0
                 else:
+                    print 'ffill, no dt, field == nan'
                     return np.nan
         else:
             # If not forward filling, we just want dt.
@@ -700,14 +702,17 @@ class DataPortal(object):
         try:
             result = reader.get_value(asset.sid, query_dt, column)
         except NoDataOnDate:
+            print 'no data for {} on date {}'.format(column, query_dt)
             if column == 'volume':
                 return 0
             else:
                 return np.nan
 
         if not ffill or (dt == query_dt) or (dt.date() == query_dt.date()):
+            #print 'already have data'
             return result
 
+        #print 'adjusting..'
         # the value we found came from a different day, so we have to adjust
         # the data if there are any adjustments on that day barrier
         return self.get_adjusted_value(

--- a/catalyst/data/dispatch_bar_reader.py
+++ b/catalyst/data/dispatch_bar_reader.py
@@ -130,12 +130,16 @@ class AssetDispatchBarReader(with_metaclass(ABCMeta)):
 
         return results
 
-
 class AssetDispatchMinuteBarReader(AssetDispatchBarReader):
 
     def _dt_window_size(self, start_dt, end_dt):
         return len(self.trading_calendar.minutes_in_range(start_dt, end_dt))
 
+
+class AssetDispatchFiveMinuteBarReader(AssetDispatchBarReader):
+
+    def _dt_window_size(self, start_dt, end_dt):
+        return len(self.trading_calendar.five_minutes_in_range(start_dt, end_dt))
 
 class AssetDispatchSessionBarReader(AssetDispatchBarReader):
 

--- a/catalyst/data/five_minute_bars.py
+++ b/catalyst/data/five_minute_bars.py
@@ -35,9 +35,9 @@ from six import with_metaclass
 from toolz import keymap, valmap
 
 from catalyst.data._minute_bar_internal import (
-    minute_value,
-    find_position_of_minute,
-    find_last_traded_position_internal
+    five_minute_value,
+    find_position_of_five_minute,
+    find_last_traded_five_minute_position_internal,
 )
 
 from catalyst.gens.sim_engine import NANOS_IN_MINUTE
@@ -48,15 +48,16 @@ from catalyst.data.us_equity_pricing import (
     check_uint64_safe,
 )
 from catalyst.utils.calendars import get_calendar
-from catalyst.utils.cli import maybe_show_progress
+from catalyst.utils.cli import (
+    item_show_count,
+    maybe_show_progress,
+)
 from catalyst.utils.memoize import lazyval
 
 logger = logbook.Logger('FiveMinuteBars')
 
 OPEN_FIVE_MINUTES_PER_DAY = 288
-US_EQUITIES_MINUTES_PER_DAY = 390
 
-DEFAULT_EXPECTEDLEN = US_EQUITIES_MINUTES_PER_DAY * 252 * 15
 DEFAULT_EXPECTEDLEN_CRYPTO = OPEN_FIVE_MINUTES_PER_DAY * 366 * 15
 
 OHLC_RATIO = 1000000
@@ -65,6 +66,8 @@ OHLC = frozenset(['open', 'high', 'low', 'close'])
 OHLCV = frozenset(['open', 'high', 'low', 'close', 'volume'])
 
 UINT64_MAX = iinfo(uint64).max
+
+NANOS_IN_FIVE_MINUTES = 5 * NANOS_IN_MINUTE
 
 class BcolzFiveMinuteOverlappingData(Exception):
     pass
@@ -83,7 +86,7 @@ class FiveMinuteBarReader(BarReader):
 def _calc_five_minute_index(market_opens, five_minutes_per_day):
     five_minutes = np.zeros(len(market_opens) * five_minutes_per_day,
                        dtype='datetime64[ns]')
-    deltas = np.arange(0, five_minutes_per_day, dtype='timedelta64[m]')
+    deltas = 5 * np.arange(0, five_minutes_per_day, dtype='timedelta64[m]')
     for i, market_open in enumerate(market_opens):
         start = market_open.asm8
         five_minute_values = start + deltas
@@ -211,7 +214,7 @@ class BcolzFiveMinuteBarMetadata(object):
     """
     FORMAT_VERSION = 3
 
-    METADATA_FILENAME = 'metadata.json'
+    METADATA_FILENAME = 'five-minute-metadata.json'
 
     @classmethod
     def metadata_path(cls, rootdir):
@@ -268,7 +271,7 @@ class BcolzFiveMinuteBarMetadata(object):
                 calendar,
                 start_session,
                 end_session,
-                minutes_per_day,
+                five_minutes_per_day,
                 version=version,
             )
 
@@ -345,7 +348,7 @@ class BcolzFiveMinuteBarMetadata(object):
             'version': self.version,
             'ohlc_ratio': self.default_ohlc_ratio,
             'ohlc_ratios_per_sid': self.ohlc_ratios_per_sid,
-            'minutes_per_day': self.five_minutes_per_day,
+            'five_minutes_per_day': self.five_minutes_per_day,
             'calendar_name': self.calendar.name,
             'start_session': str(self.start_session.date()),
             'end_session': str(self.end_session.date()),
@@ -461,7 +464,7 @@ class BcolzFiveMinuteBarWriter(object):
                  five_minutes_per_day,
                  default_ohlc_ratio=OHLC_RATIO,
                  ohlc_ratios_per_sid=None,
-                 expectedlen=DEFAULT_EXPECTED_CRYPTO_LEN,
+                 expectedlen=DEFAULT_EXPECTEDLEN_CRYPTO,
                  write_metadata=True):
 
         self._rootdir = rootdir
@@ -477,11 +480,11 @@ class BcolzFiveMinuteBarWriter(object):
         self._default_ohlc_ratio = default_ohlc_ratio
         self._ohlc_ratios_per_sid = ohlc_ratios_per_sid
 
-        self._minute_index = _calc_minute_index(
-            self._schedule.market_open, self._minutes_per_day)
+        self._five_minute_index = _calc_five_minute_index(
+            self._schedule.market_open, self._five_minutes_per_day)
 
         if write_metadata:
-            metadata = BcolzMinuteBarMetadata(
+            metadata = BcolzFiveMinuteBarMetadata(
                 self._default_ohlc_ratio,
                 self._ohlc_ratios_per_sid,
                 self._calendar,
@@ -678,7 +681,11 @@ class BcolzFiveMinuteBarWriter(object):
         for k, v in kwargs.items():
             table.attrs[k] = v
 
-    def write(self, data, show_progress=False, invalid_data_behavior='warn'):
+    def write(self,
+              data,
+              length=None,
+              show_progress=False,
+              invalid_data_behavior='warn'):
         """Write a stream of minute data.
 
         Parameters
@@ -698,14 +705,15 @@ class BcolzFiveMinuteBarWriter(object):
         show_progress : bool, optional
             Whether or not to show a progress bar while writing.
         """
-        ctx = maybe_show_progress(
+        with maybe_show_progress(
             data,
+            length=length,
+            show_percent=False,
             show_progress=show_progress,
-            item_show_func=lambda e: e if e is None else str(e[0]),
-            label="Merging minute equity files:",
-        )
-        write_sid = self.write_sid
-        with ctx as it:
+            item_show_func=item_show_count(length),
+            label='Compiling five-minute data',
+        ) as it:
+            write_sid = self.write_sid
             for e in it:
                 write_sid(*e, invalid_data_behavior=invalid_data_behavior)
 
@@ -807,9 +815,12 @@ class BcolzFiveMinuteBarWriter(object):
         # Get the number of minutes already recorded in this sid's ctable
         num_rec_mins = table.size
 
-        all_minutes = self._minute_index
+        all_minutes = self._five_minute_index
         # Get the latest minute we wish to write to the ctable
         last_minute_to_write = pd.Timestamp(dts[-1], tz='UTC')
+
+        #print 'all_minutes[-1]:', all_minutes[num_rec_mins-1]
+        #print 'last_minute_to_write:', last_minute_to_write
 
         # In the event that we've already written some minutely data to the
         # ctable, guard against overwriting that data.
@@ -864,7 +875,7 @@ class BcolzFiveMinuteBarWriter(object):
         day_ix = self._session_labels.get_loc(day)
         # Add one to the 0-indexed day_ix to get the number of days.
         num_days = day_ix + 1
-        return num_days * self._minutes_per_day
+        return num_days * self._five_minutes_per_day
 
     def truncate(self, date):
         """Truncate data beyond this date in all ctables."""
@@ -1002,7 +1013,7 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         market_closes = self._market_closes.values.astype('datetime64[m]')
         minutes_per_day = (market_closes - market_opens).astype(np.int64) / 5
         early_indices = np.where(
-            minutes_per_day != self._minutes_per_day - 1)[0]
+            minutes_per_day != self._five_minutes_per_day - 1)[0]
         early_opens = self._market_opens[early_indices]
         early_closes = self._market_closes[early_indices]
         minutes = [(market_open, early_close)
@@ -1030,9 +1041,9 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         """
         itree = IntervalTree()
         for market_open, early_close in self._minutes_to_exclude():
-            start_pos = self._find_position_of_minute(early_close) + 1
+            start_pos = self._find_position_of_five_minute(early_close) + 1
             end_pos = (
-                self._find_position_of_minute(market_open)
+                self._find_position_of_five_minute(market_open)
                 +
                 self._five_minutes_per_day
                 -
@@ -1121,7 +1132,7 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
             minute_pos = self._last_get_value_dt_position
         else:
             try:
-                minute_pos = self._find_position_of_minute(dt)
+                minute_pos = self._find_position_of_five_minute(dt)
             except ValueError:
                 raise NoDataOnDate()
 
@@ -1143,15 +1154,15 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         return value
 
     def get_last_traded_dt(self, asset, dt):
-        minute_pos = self._find_last_traded_position(asset, dt)
+        minute_pos = self._find_last_traded_five_minute_position(asset, dt)
         if minute_pos == -1:
             return pd.NaT
         return self._pos_to_minute(minute_pos)
 
-    def _find_last_traded_position(self, asset, dt):
+    def _find_last_traded_five_minute_position(self, asset, dt):
         volumes = self._open_minute_file('volume', asset)
-        start_date_minute = asset.start_date.value / NANOS_IN_MINUTE
-        dt_minute = dt.value / NANOS_IN_MINUTE
+        start_date_minute = asset.start_date.value / NANOS_IN_FIVE_MINUTE
+        dt_minute = dt.value / NANOS_IN_FIVE_MINUTE
 
         try:
             # if we know of a dt before which this asset has no volume,
@@ -1163,13 +1174,13 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         if dt_minute < earliest_dt_to_search:
             return -1
 
-        pos = find_last_traded_position_internal(
+        pos = find_last_traded_five_minute_position_internal(
             self._market_open_values,
             self._market_close_values,
             dt_minute,
             earliest_dt_to_search,
             volumes,
-            self._minutes_per_day,
+            self._five_minutes_per_day,
         )
 
         if pos == -1:
@@ -1186,15 +1197,15 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         return pos
 
     def _pos_to_minute(self, pos):
-        minute_epoch = minute_value(
+        minute_epoch = five_minute_value(
             self._market_open_values,
             pos,
-            self._minutes_per_day
+            self._five_minutes_per_day
         )
 
         return pd.Timestamp(minute_epoch, tz='UTC', unit="m")
 
-    def _find_position_of_minute(self, minute_dt):
+    def _find_position_of_five_minute(self, minute_dt):
         """
         Internal method that returns the position of the given minute in the
         list of every trading minute since market open of the first trading
@@ -1213,11 +1224,11 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         int: The position of the given minute in the list of all trading
         minutes since market open on the first trading day.
         """
-        return find_position_of_minute(
+        return find_position_of_five_minute(
             self._market_open_values,
             self._market_close_values,
-            minute_dt.value / NANOS_IN_MINUTE,
-            self._minutes_per_day,
+            minute_dt.value / NANOS_IN_FIVE_MINUTE,
+            self._five_minutes_per_day,
             False,
         )
 
@@ -1241,8 +1252,8 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
             (minutes in range, sids) with a dtype of float64, containing the
             values for the respective field over start and end dt range.
         """
-        start_idx = self._find_position_of_minute(start_dt)
-        end_idx = self._find_position_of_minute(end_dt)
+        start_idx = self._find_position_of_five_minute(start_dt)
+        end_idx = self._find_position_of_five_minute(end_dt)
 
         num_minutes = (end_idx - start_idx + 1)
 
@@ -1261,7 +1272,7 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
             if field != 'volume':
                 out = np.full(shape, np.nan)
             else:
-                out = np.zeros(shape, dtype=int64)
+                out = np.zeros(shape, dtype=uint64)
 
             for i, sid in enumerate(sids):
                 carray = self._open_minute_file(field, sid)

--- a/catalyst/data/five_minute_bars.py
+++ b/catalyst/data/five_minute_bars.py
@@ -60,7 +60,7 @@ OPEN_FIVE_MINUTES_PER_DAY = 288
 
 DEFAULT_EXPECTEDLEN_CRYPTO = OPEN_FIVE_MINUTES_PER_DAY * 366 * 15
 
-OHLC_RATIO = 1000000
+OHLC_RATIO = 1000
 
 OHLC = frozenset(['open', 'high', 'low', 'close'])
 OHLCV = frozenset(['open', 'high', 'low', 'close', 'volume'])

--- a/catalyst/data/five_minute_bars.py
+++ b/catalyst/data/five_minute_bars.py
@@ -1151,6 +1151,7 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
 
         if field != 'volume':
             value *= self._ohlc_ratio_inverse_for_sid(sid)
+        #print 'minute pos: {}, {}: {}'.format(minute_pos, field, value)
         return value
 
     def get_last_traded_dt(self, asset, dt):
@@ -1161,8 +1162,8 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
 
     def _find_last_traded_five_minute_position(self, asset, dt):
         volumes = self._open_minute_file('volume', asset)
-        start_date_minute = asset.start_date.value / NANOS_IN_FIVE_MINUTE
-        dt_minute = dt.value / NANOS_IN_FIVE_MINUTE
+        start_date_minute = asset.start_date.value / NANOS_IN_MINUTE
+        dt_minute = dt.value / NANOS_IN_MINUTE
 
         try:
             # if we know of a dt before which this asset has no volume,
@@ -1227,7 +1228,7 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
         return find_position_of_five_minute(
             self._market_open_values,
             self._market_close_values,
-            minute_dt.value / NANOS_IN_FIVE_MINUTE,
+            minute_dt.value / NANOS_IN_MINUTE,
             self._five_minutes_per_day,
             False,
         )
@@ -1252,10 +1253,18 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
             (minutes in range, sids) with a dtype of float64, containing the
             values for the respective field over start and end dt range.
         """
+        print 'start_dt:', start_dt
+        print 'end_dt:', end_dt
+
         start_idx = self._find_position_of_five_minute(start_dt)
         end_idx = self._find_position_of_five_minute(end_dt)
 
+        print 'start_idx:', start_idx
+        print 'end_idex:', end_idx
+
         num_minutes = (end_idx - start_idx + 1)
+
+        print 'num_minutes:', num_minutes
 
         results = []
 
@@ -1293,6 +1302,8 @@ class BcolzFiveMinuteBarReader(FiveMinuteBarReader):
                     out[:len(where), i][where] = values[where]
 
             results.append(out)
+
+        print 'results:', results
         return results
 
 

--- a/catalyst/data/us_equity_pricing.py
+++ b/catalyst/data/us_equity_pricing.py
@@ -229,7 +229,7 @@ class BcolzDailyBarWriter(object):
 
     @property
     def progress_bar_message(self):
-        return 'Compiling daily pricing data'
+        return 'Compiling daily data'
 
     def write(self,
               data,

--- a/catalyst/examples/buy_and_hodl.5min.py
+++ b/catalyst/examples/buy_and_hodl.5min.py
@@ -25,6 +25,7 @@ from catalyst.api import (
     get_open_orders,
 )
 
+
 def initialize(context):
     context.ASSET_NAME = 'USDT_BTC'
     context.TARGET_HODL_RATIO = 0.8

--- a/catalyst/examples/buy_and_hodl.py
+++ b/catalyst/examples/buy_and_hodl.py
@@ -25,7 +25,7 @@ from catalyst.api import (
 
 
 def initialize(context):
-    context.ASSET_NAME = 'USDT_ETH'
+    context.ASSET_NAME = 'USDT_BTC'
     context.TARGET_HODL_RATIO = 0.8
     context.RESERVE_RATIO = 1.0 - context.TARGET_HODL_RATIO
 
@@ -37,7 +37,13 @@ def initialize(context):
     context.is_buying = True
     context.asset = symbol(context.ASSET_NAME)
 
+    context.i = 0
+
 def handle_data(context, data):
+    context.i += 1
+
+    print 'i:', context.i
+
     starting_cash = context.portfolio.starting_cash
     target_hodl_value = context.TARGET_HODL_RATIO * starting_cash
     reserve_value = context.RESERVE_RATIO * starting_cash

--- a/catalyst/examples/dual_vwap.5min.py
+++ b/catalyst/examples/dual_vwap.5min.py
@@ -23,6 +23,7 @@ from catalyst.api import (
     set_max_leverage,
     schedule_function,
     date_rules,
+    time_rules,
     attach_pipeline,
     pipeline_output,
 )
@@ -35,8 +36,8 @@ from catalyst.pipeline.factors.crypto import VWAP
 def initialize(context):
     context.ASSET_NAME = 'USDT_BTC'
     context.TARGET_INVESTMENT_RATIO = 0.8
-    context.SHORT_WINDOW = 30
-    context.LONG_WINDOW = 100
+    context.SHORT_WINDOW = 30 * 288
+    context.LONG_WINDOW = 100 * 288
 
     # For all trading pairs in the poloniex bundle, the default denomination
     # currently supported by Catalyst is 1/1000th of a full coin. Use this
@@ -52,7 +53,7 @@ def initialize(context):
 
     schedule_function(
         rebalance,
-        date_rule=date_rules.every_day(),
+        time_rule=time_rules.every_minute(),
     )
 
 

--- a/catalyst/examples/dual_vwap.py
+++ b/catalyst/examples/dual_vwap.py
@@ -52,7 +52,7 @@ def initialize(context):
 
     schedule_function(
         rebalance,
-        date_rules.every_day(),
+        time_rules=times_rules.every_minute(),
     )
 
 

--- a/catalyst/finance/performance/tracker.py
+++ b/catalyst/finance/performance/tracker.py
@@ -189,14 +189,14 @@ class PerformanceTracker(object):
 
     @property
     def progress(self):
-        if self.emission_rate == 'minute':
+        if self.emission_rate in set(('minute', '5-minute')):
             # Fake a value
             return 1.0
         elif self.emission_rate == 'daily':
             return self.session_count / self.total_session_count
 
     def set_date(self, date):
-        if self.emission_rate == 'minute':
+        if self.emission_rate in set(('minute', '5-minute')):
             self.saved_dt = date
             self.todays_performance.period_close = self.saved_dt
 
@@ -370,7 +370,9 @@ class PerformanceTracker(object):
                                             bench_since_open,
                                             account.leverage)
 
+        assert self.emission_rate in set(('minute', '5-minute'))
         minute_packet = self.to_dict(emission_type='minute')
+
         return minute_packet
 
     def handle_market_close(self, dt, data_portal):

--- a/catalyst/finance/performance/tracker.py
+++ b/catalyst/finance/performance/tracker.py
@@ -111,6 +111,21 @@ class PerformanceTracker(object):
                     self.treasury_curves,
                     self.trading_calendar
                 )
+        elif self.emission_rate == '5-minute':
+            self.all_benchmark_returns = pd.Series(
+                index=pd.date_range(
+                    self.sim_params.first_open,
+                    self.sim_params.last_close,
+                    freq='5min'
+                ),
+            )
+            self.cumulative_risk_metrics = \
+                risk.RiskMetricsCumulative(
+                    self.sim_params,
+                    self.treasury_curves,
+                    self.trading_calendar,
+                    create_first_day_stats=True,
+                )
         elif self.emission_rate == 'minute':
             self.all_benchmark_returns = pd.Series(index=pd.date_range(
                 self.sim_params.first_open, self.sim_params.last_close,

--- a/catalyst/gens/sim_engine.pyx
+++ b/catalyst/gens/sim_engine.pyx
@@ -131,7 +131,7 @@ cdef class FiveMinuteSimulationClock(MinuteSimulationClock):
         for session_idx, session_nano in enumerate(self.sessions_nanos):
             five_minutes_nanos = np.arange(
                 self.market_opens_nanos[session_idx],
-                self.market_closes_nanos[session_idx] + _nanos_in_five_minutes,
+                self.market_closes_nanos[session_idx],
                 _nanos_in_five_minutes
             )
             five_minutes_by_session[session_nano] = pd.to_datetime(

--- a/catalyst/pipeline/loaders/crypto_pricing_loader.py
+++ b/catalyst/pipeline/loaders/crypto_pricing_loader.py
@@ -37,6 +37,7 @@ class CryptoPricingLoader(PipelineLoader):
 
         cal = get_calendar('OPEN')
 
+        print 'CryptoPricingLoader-{}'.format(data_frequency)
         if data_frequency == 'daily':
             reader = bundle.daily_bar_reader
             all_sessions = cal.all_sessions
@@ -57,6 +58,7 @@ class CryptoPricingLoader(PipelineLoader):
         self.raw_price_loader = reader
         self._columns = dataset.columns
         self._all_sessions = all_sessions
+        self._data_frequency = data_frequency
 
     @classmethod
     def from_files(cls, pricing_path):

--- a/catalyst/utils/cli.py
+++ b/catalyst/utils/cli.py
@@ -17,6 +17,7 @@ def item_show_count(total=None):
 
     def item_show_func(item, _it=iter(count())):
         if item is not None:
+            starting = False
             return maybe_show_total(next(_it))
         return 'DONE'
 

--- a/catalyst/utils/run_algo.py
+++ b/catalyst/utils/run_algo.py
@@ -156,15 +156,15 @@ def _run(handle_data,
                 environ=environ,
             )
 
-            first_trading_day =\
-                bundle_data.equity_minute_bar_reader.first_trading_day
+            first_trading_day = bundle_data.minute_bar_reader.first_trading_day
 
             data = DataPortal(
                 env.asset_finder,
                 open_calendar,
                 first_trading_day=first_trading_day,
-                equity_minute_reader=bundle_data.equity_minute_bar_reader,
-                equity_daily_reader=bundle_data.equity_daily_bar_reader,
+                minute_reader=bundle_data.minute_bar_reader,
+                five_minute_reader=bundle_data.five_minute_bar_reader,
+                daily_reader=bundle_data.daily_bar_reader,
                 adjustment_reader=bundle_data.adjustment_reader,
             )
 
@@ -179,13 +179,14 @@ def _run(handle_data,
 
             if b == 'poloniex':
                 return CryptoPricingLoader(
-                           bundle_data.equity_daily_bar_reader,
+                           bundle_data,
+                           data_frequency,
                            CryptoPricing,
                        )
-            elif b == 'quantopian-quandl':
+            elif b == 'quandl':
                 return USEquityPricingLoader(
-                           bundle_data.equity_daily_bar_reader,
-                           bundle_data.adjustment_reader,
+                           bundle_data,
+                           data_frequency,
                            USEquityPricing,
                        )
             raise ValueError(
@@ -216,6 +217,7 @@ def _run(handle_data,
             end=end,
             capital_base=capital_base,
             data_frequency=data_frequency,
+            emission_rate=data_frequency,
         ),
         **{
             'initialize': initialize,


### PR DESCRIPTION
Large scale refactor to use generic bundle and integrate five minute data.

 * Client now supports `5-minute` data-frequency in both handle_data and pipeline
 * Bundles can be ingested at specific frequencies
 * Adds control flows for five minute backtesting


This closes #5, closes #6, closes #7, closes #8, closes #9, and closes #10