### PR TITLE
DOC: fix import and support python3 for beginner tutorial

### DIFF
--- a/catalyst/examples/dual_moving_average.py
+++ b/catalyst/examples/dual_moving_average.py
@@ -84,7 +84,8 @@ def handle_data(context, data):
 def analyze(context, perf):
 
     # Get the base_currency that was passed as a parameter to the simulation
-    base_currency = context.exchanges.values()[0].base_currency.upper()
+    exchange = list(context.exchanges.values())[0]
+    base_currency = exchange.base_currency.upper()
 
     # First chart: Plot portfolio value using base_currency
     ax1 = plt.subplot(411)

--- a/docs/source/beginner-tutorial.rst
+++ b/docs/source/beginner-tutorial.rst
@@ -589,7 +589,7 @@ the ``examples`` directory:
     from catalyst import run_algorithm
     from catalyst.api import (order, record, symbol, order_target_percent, 
             get_open_orders)
-    from catalyst.exchange.stats_utils import extract_transactions
+    from catalyst.exchange.utils.stats_utils import extract_transactions
 
     NAMESPACE = 'dual_moving_average'
     log = Logger(NAMESPACE)
@@ -660,7 +660,8 @@ the ``examples`` directory:
     def analyze(context, perf):
 
         # Get the base_currency that was passed as a parameter to the simulation
-        base_currency = context.exchanges.values()[0].base_currency.upper()
+        exchange = list(context.exchanges.values())[0]
+        base_currency = exchange.base_currency.upper()
 
         # First chart: Plot portfolio value using base_currency
         ax1 = plt.subplot(411)


### PR DESCRIPTION
The beginner tutorial Dual Moving Average example attempted to import
extract_transactions from the wrong location.

The tutorial and corresponding example also would fail using python3
due to indexing the view object returned via context.exchange.values()