### PR TITLE
Allow jupyter to run as root inside Docker image

### DIFF
--- a/etc/docker_cmd.sh
+++ b/etc/docker_cmd.sh
@@ -16,4 +16,4 @@ fi
 
 jupyter notebook -y --no-browser --notebook-dir=${PROJECT_DIR} \
     --certfile=${SSL_CERT_PEM} --keyfile=${SSL_CERT_KEY} --ip='*' \
-    --config=${CONFIG_PATH}
+    --config=${CONFIG_PATH} --allow-root


### PR DESCRIPTION
Starting a container with an image built from the provided Dockerfile fails with the following error:

```
Writing default config to: /root/.jupyter/jupyter_notebook_config.py
Generating a 2048 bit RSA private key
..+++
...........+++
writing new private key to '/root/.jupyter/jupyter.key'
-----
[I 10:47:38.664 NotebookApp] Writing notebook server cookie secret to /root/.local/share/jupyter/runtime/notebook_cookie_secret
[C 10:47:39.214 NotebookApp] Running as root is not recommended. Use --allow-root to bypass.
```
This pull request adds `--allow-root` to the script used to run jupyter and allows the container to start correctly.