### PR TITLE
BUG: Use empyrical patches for persisting issue #126

### DIFF
--- a/catalyst/finance/risk/period.py
+++ b/catalyst/finance/risk/period.py
@@ -29,12 +29,14 @@ from .risk import check_entry
 from empyrical import (
     alpha_beta_aligned,
     annual_volatility,
-    cum_returns,
     downside_risk,
     information_ratio,
-    max_drawdown,
     sharpe_ratio,
     sortino_ratio
+)
+from catalyst.patches.stats import (
+    max_drawdown,
+    cum_returns,
 )
 
 from catalyst.constants import LOG_LEVEL

--- a/etc/requirements_docs.txt
+++ b/etc/requirements_docs.txt
@@ -1,3 +1,4 @@
 Sphinx>=1.3.2
 numpydoc>=0.5.0
 sphinx-autobuild==0.6.0
+docutils==0.12


### PR DESCRIPTION
The referenced issue #126 was addressed via importing a set of patches
for empyrical. However the same error occurs occasionally when calling
the empyrical functions inside "/catalyst/finance/risk/period.py".

This PR simply applies 2 of the same patches in period.py.
I have only experienced problems with cum_returns and max_drawdown
thus far, but it is likely the other patches may be needed.