### PR TITLE
Local variable 'transaction' referenced before assignment

### DIFF
--- a/catalyst/exchange/ccxt/ccxt_exchange.py
+++ b/catalyst/exchange/ccxt/ccxt_exchange.py
@@ -869,6 +869,8 @@ class CCXT(Exchange):
         order.commission = exc_order.commission
         order.filled = exc_order.amount
 
+        transactions = []
+
         if exc_order.status == ORDER_STATUS.FILLED:
             if order.amount > exc_order.amount:
                 log.warn(
@@ -882,15 +884,17 @@ class CCXT(Exchange):
                 price=price,
                 dt=exc_order.dt,
             )
-            transaction = Transaction(
-                asset=order.asset,
-                amount=order.amount,
-                dt=pd.Timestamp.utcnow(),
-                price=price,
-                order_id=order.id,
-                commission=order.commission,
+            transactions.append(
+                Transaction(
+                    asset=order.asset,
+                    amount=order.amount,
+                    dt=pd.Timestamp.utcnow(),
+                    price=price,
+                    order_id=order.id,
+                    commission=order.commission,
+                )
             )
-        return [transaction]
+        return transactions
 
     def process_order(self, order):
         # TODO: move to parent class after tracking features in the parent


### PR DESCRIPTION
Following error occured when executing a buy on Bittrex while live trading:

Command:
```
order_target_percent(asset=asset, target=1, limit_price=price * 1.0001)
```

Traceback:
```
Traceback (most recent call last):
  File "/home/ubuntu/my_algo.py", line 290, in <module>
    simulate_orders=False)
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/utils/run_algo.py", line 551, in run_algorithm
    stats_output=stats_output
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/utils/run_algo.py", line 330, in _run
    overwrite_sim_params=False,
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/exchange/exchange_algorithm.py", line 297, in run
    data, overwrite_sim_params
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/algorithm.py", line 724, in run
    for perf in self.get_generator():
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/gens/tradesimulation.py", line 224, in transform
    for capital_change_packet in every_bar(dt):
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/gens/tradesimulation.py", line 122, in every_bar
    blotter.get_transactions(current_data)
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/exchange/exchange_blotter.py", line 271, in get_transactions
    cleanup=lambda: log.warn(
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/redo/__init__.py", line 162, in retry
    return action(*args, **kwargs)
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/exchange/exchange_blotter.py", line 252, in get_exchange_transactions
    for order, txn in self.check_open_orders():
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/exchange/exchange_blotter.py", line 211, in check_open_orders
    transactions = exchange.process_order(order)
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/exchange/ccxt/ccxt_exchange.py", line 898, in process_order
    return self._process_order_fallback(order)
  File "/home/ubuntu/anaconda3/envs/catalyst/lib/python2.7/site-packages/catalyst/exchange/ccxt/ccxt_exchange.py", line 893, in _process_order_fallback
    return [transaction]
UnboundLocalError: local variable 'transaction' referenced before assignment
```