### PR TITLE
Add get_open_orders function to api.pyi file

### DIFF
--- a/catalyst/api.pyi
+++ b/catalyst/api.pyi
@@ -830,3 +830,17 @@ def get_dataset(ds_name, start=None, end=None):
     -------
 
     """
+
+
+def get_open_orders(asset):
+    """
+    List open orders on the exchange regardless who placed them.
+
+    Parameters
+    ----------
+    asset: Asset
+
+    Returns
+    -------
+    orders : list[Order]
+    """


### PR DESCRIPTION
An error is issued in `buy_low_sell_high.py` because `api.py` does not have `get_open_orders()`.

**buy_low_sell_high.py**
```
from catalyst.api import (
    order,
    order_target_percent,
    symbol,
    record,
    get_open_orders,
)
```

So I implemented the function `get_open_orders()` in `api.py`.