### PR TITLE
Exchange: support availabe spot values

### DIFF
--- a/catalyst/exchange/exchange.py
+++ b/catalyst/exchange/exchange.py
@@ -370,11 +370,13 @@ class Exchange:
         if field == 'close' or field == 'price':
             return [tickers[asset]['last'] for asset in tickers]
 
-        elif field == 'volume':
-            return [tickers[asset]['volume'] for asset in tickers]
-
-        else:
-            raise NoValueForField(field=field)
+        result = []
+        for asset in tickers:
+            if field in tickers[asset]:
+                result.append(tickers[asset][field])
+            else:
+                raise NoValueForField(field=field)
+        return result
 
     def get_single_spot_value(self, asset, field, data_frequency):
         """


### PR DESCRIPTION
The documentation says, that open, high, low, close, volume, price and last_traded is supported, but only close/price and volume was supported. I changed it now, but the documentation is still incorrect, because dt and data_frequency is not used. I think, the documentation just got copied from DataPortal::get_spot_value. I changed it, so I can use data.current for backtesting and live-trading.

I have not found tests for this, if I should write some, please let me know, where the appropriate place is.