### PR TITLE
order status has no property cost

### DIFF
--- a/catalyst/exchange/ccxt/ccxt_exchange.py
+++ b/catalyst/exchange/ccxt/ccxt_exchange.py
@@ -729,7 +729,10 @@ class CCXT(Exchange):
 
         limit_price = price if order_type == 'limit' else None
 
-        executed_price = order_status['cost'] / order_status['amount']
+        if "cost" in order_status and "amount" in order_status:
+            executed_price = order_status['cost'] / order_status['amount']
+        else:
+            executed_price = None
         commission = order_status['fee']
         date = from_ms_timestamp(order_status['timestamp'])
 


### PR DESCRIPTION
When I execute an order on bitfinex and immediately call `get_order` to get the order, I get a KeyError: 'cost' here:
>   File ".../catalyst/utils/api_support.py", line 57, in wrapped
>     return getattr(algo_instance, f.__name__)(*args, **kwargs)
>   File ".../catalyst/exchange/exchange_algorithm.py", line 1110, in get_order
>     args=(order_id,))
>   File ".../redo/__init__.py", line 162, in retry
>     return action(*args, **kwargs)
>   File ".../catalyst/exchange/ccxt/ccxt_exchange.py", line 1140, in get_order
>     order, executed_price = self._create_order(order_status)
>   File ".../catalyst/exchange/ccxt/ccxt_exchange.py", line 725, in _create_order
>     executed_price = order_status['cost'] / order_status['amount']

If there is a better solution to fix this, please let me know.