### PR TITLE
Remove the 3 second sleep from run

### DIFF
--- a/catalyst/utils/run_algo.py
+++ b/catalyst/utils/run_algo.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 from datetime import timedelta
 from runpy import run_path
-from time import sleep
 
 import click
 import pandas as pd
@@ -148,7 +147,6 @@ def _run(handle_data,
 
     log.warn(ALPHA_WARNING_MESSAGE)
     log.info('Catalyst version {}'.format(catalyst.__version__))
-    sleep(3)
 
     if live:
         if simulate_orders:


### PR DESCRIPTION
While back testing I run many simulations with different input parameters, having a 3 second sleep per run is really adding to the total time. I can't test all the parameters in parallel as I am using Bayesian optimization. Therefore sometimes this sleep can take up 5 minutes of time.