### PR TITLE
Allow users to disable the alpha warning + sleep

### DIFF
--- a/catalyst/constants.py
+++ b/catalyst/constants.py
@@ -45,6 +45,8 @@ ENIGMA_CONTRACT_ABI = 'https://raw.githubusercontent.com/enigmampc/' \
 SUPPORTED_WALLETS = ['metamask', 'ledger', 'trezor', 'bitbox', 'keystore',
                      'key']
 
+DISABLE_ALPHA_WARNING = bool(os.environ.get('CATALYST_DISABLE_ALPHA_WARNING'))
+
 ALPHA_WARNING_MESSAGE = 'Catalyst is currently in ALPHA. It is going ' \
                         'through rapid development and it is subject to ' \
                         'errors. Please use carefully. We encourage you to ' \

--- a/catalyst/utils/run_algo.py
+++ b/catalyst/utils/run_algo.py
@@ -43,7 +43,7 @@ from catalyst.exchange.exchange_data_portal import DataPortalExchangeLive, \
     DataPortalExchangeBacktest
 from catalyst.exchange.exchange_asset_finder import ExchangeAssetFinder
 
-from catalyst.constants import LOG_LEVEL, ALPHA_WARNING_MESSAGE
+from catalyst.constants import LOG_LEVEL, ALPHA_WARNING_MESSAGE, DISABLE_ALPHA_WARNING
 
 log = Logger('run_algo', level=LOG_LEVEL)
 
@@ -146,9 +146,10 @@ def _run(handle_data,
         else:
             click.echo(algotext)
 
-    log.warn(ALPHA_WARNING_MESSAGE)
     log.info('Catalyst version {}'.format(catalyst.__version__))
-    sleep(3)
+    if not DISABLE_ALPHA_WARNING:
+        log.warn(ALPHA_WARNING_MESSAGE)
+        sleep(3)
 
     if live:
         if simulate_orders:

--- a/catalyst/utils/run_algo.py
+++ b/catalyst/utils/run_algo.py
@@ -43,7 +43,8 @@ from catalyst.exchange.exchange_data_portal import DataPortalExchangeLive, \
     DataPortalExchangeBacktest
 from catalyst.exchange.exchange_asset_finder import ExchangeAssetFinder
 
-from catalyst.constants import LOG_LEVEL, ALPHA_WARNING_MESSAGE, DISABLE_ALPHA_WARNING
+from catalyst.constants import LOG_LEVEL, ALPHA_WARNING_MESSAGE, \
+    DISABLE_ALPHA_WARNING
 
 log = Logger('run_algo', level=LOG_LEVEL)
 


### PR DESCRIPTION
By setting the `$DISABLE_ALPHA_WARNING` environment variable to
anything else than an empty string, users can now disable
the warning about Catalyst being in alpha, and the associated three
seconds delay.

Fixes #493