### PR TITLE
ENH: Solution for #503 - HTTP(S) proxy-settings for CCXT

### DIFF
--- a/catalyst/exchange/ccxt/ccxt_exchange.py
+++ b/catalyst/exchange/ccxt/ccxt_exchange.py
@@ -64,11 +64,22 @@ class CCXT(Exchange):
             else:
                 exchange_attr = getattr(ccxt, exchange_name)
 
-            self.api = exchange_attr({
+            exchange_config = {
                 'apiKey': key,
                 'secret': secret,
-                'password': password,
-            })
+                'password': password
+            }
+
+            if('HTTP_PROXY' in os.environ or 'HTTPS_PROXY' in os.environ):
+                exchange_config['proxies'] = {}
+
+                if('HTTP_PROXY' in os.environ):
+                    exchange_config['proxies']['HTTP_PROXY'] = os.environ['HTTP_PROXY']
+
+                if ('HTTPS_PROXY' in os.environ):
+                    exchange_config['proxies']['HTTPS_PROXY'] = os.environ['HTTPS_PROXY']
+
+            self.api = exchange_attr(exchange_config)
             self.api.enableRateLimit = True
 
         except Exception:


### PR DESCRIPTION
Pass env parameters HTTP_PROXY and HTTPS_PROXY parameter from env if they are set.

Solution for: https://github.com/enigmampc/catalyst/issues/503