### PR TITLE
BLD: Updated numpy to version 1.16.3 since 1.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir ${PROJECT_DIR} \
 
 WORKDIR /ta-lib
 
-RUN pip install 'numpy==1.14.0' \
+RUN pip install 'numpy==1.16.3' \
   && pip install 'scipy==1.0.0' \
   && pip install 'pandas==0.19.2' \
   && ./configure --prefix=/usr \

--- a/etc/python2.7-environment.yml
+++ b/etc/python2.7-environment.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 dependencies:
 - certifi=2016.2.28=py27_0
-- numpy=1.14.0
+- numpy=1.16.3
 - openssl=1.0.2l
 - pip=9.0.1=py27_1
 - python=2.7.13

--- a/etc/python3.6-environment-windows.yml
+++ b/etc/python3.6-environment-windows.yml
@@ -7,7 +7,7 @@ dependencies:
 - certifi=2018.1.18
 - intel-openmp=2018.0.0
 - mkl=2018.0.1
-- numpy=1.14.0
+- numpy=1.16.3
 - openssl=1.0.2n
 - matplotlib=2.2.2
 - pip=9.0.1

--- a/etc/python3.6-environment.yml
+++ b/etc/python3.6-environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - ipython=6.4.0
 - jupyter=1.0.0
 - mkl=2018.0.1
-- numpy=1.14.0
+- numpy=1.16.3
 - openssl=1.0.2n
 - matplotlib=2.2.2
 - pip=9.0.1

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -10,8 +10,8 @@ Logbook==0.12.5
 
 pytz==2016.4
 
-# FF: Upgraded numpy because of errors with version 1.11
-numpy==1.14.0
+# FF: Upgraded numpy because of errors with version 1.14
+numpy==1.16.3
 
 # for pandas-datareader
 requests-file==1.4.3


### PR DESCRIPTION
I get the following error when using numpy version 1.14.0 when installed from package with pip or in development enviroment: ModuleNotFoundError: No module named 'numpy.core._multiarray_umath'

The error goes away when I upgrade numpy library